### PR TITLE
Update package name to help differentiate our own package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 import sys
 from setuptools import setup, find_packages
 
-NAME = "looker-api-client"
-VERSION = "1.0.1"
+NAME = "grove-looker"
+VERSION = "1.0.2"
 
 
 # To install the library, run the following


### PR DESCRIPTION
## Reason for change
Based on comment https://github.com/groveco/grove/pull/10321#pullrequestreview-545203080, renaming package helps to differentiate our own package.

Per comment in https://groveco.slack.com/archives/CJBRG197B/p1607024946015800, the official Looker SDK is a lot different than the generated SDK that we're currently using - so renaming is the appropriate option.